### PR TITLE
Synchronize volume across player types

### DIFF
--- a/www/assets/js/callbacks.js
+++ b/www/assets/js/callbacks.js
@@ -1,5 +1,4 @@
 /*
-return null;
 The MIT License (MIT)
 Copyright (c) 2013 Calvin Montgomery
 
@@ -1010,6 +1009,13 @@ Callbacks = {
     },
 
     changeMedia: function(data) {
+        if (PLAYER) {
+            console.log('getting volume for', PLAYER.type);
+            PLAYER.getVolume(function (v) {
+                VOLUME = v;
+            });
+        }
+
         if(CHANNEL.opts.allow_voteskip)
             $("#voteskip").attr("disabled", false);
 

--- a/www/assets/js/callbacks.js
+++ b/www/assets/js/callbacks.js
@@ -1010,7 +1010,6 @@ Callbacks = {
 
     changeMedia: function(data) {
         if (PLAYER) {
-            console.log('getting volume for', PLAYER.type);
             PLAYER.getVolume(function (v) {
                 VOLUME = v;
                 setOpt("volume", VOLUME);

--- a/www/assets/js/callbacks.js
+++ b/www/assets/js/callbacks.js
@@ -1013,6 +1013,7 @@ Callbacks = {
             console.log('getting volume for', PLAYER.type);
             PLAYER.getVolume(function (v) {
                 VOLUME = v;
+                setOpt("volume", VOLUME);
             });
         }
 

--- a/www/assets/js/data.js
+++ b/www/assets/js/data.js
@@ -36,7 +36,6 @@ var CHANNEL = {
 };
 
 var PLAYER = false;
-var VOLUME = 1;
 var VIDEOQUALITY = false;
 var FLUIDLAYOUT = false;
 var VWIDTH;
@@ -123,6 +122,8 @@ var USEROPTS = {
     boop                 : getOrDefault("boop", false),
     secure_connection    : getOrDefault("secure_connection", false)
 };
+
+var VOLUME = getOrDefault("volume", 1);
 
 var NO_WEBSOCKETS = USEROPTS.altsocket;
 

--- a/www/assets/js/data.js
+++ b/www/assets/js/data.js
@@ -1,11 +1,11 @@
 /*
 The MIT License (MIT)
 Copyright (c) 2013 Calvin Montgomery
- 
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- 
+
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- 
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
@@ -36,6 +36,7 @@ var CHANNEL = {
 };
 
 var PLAYER = false;
+var VOLUME = 1;
 var VIDEOQUALITY = false;
 var FLUIDLAYOUT = false;
 var VWIDTH;

--- a/www/assets/js/player.js
+++ b/www/assets/js/player.js
@@ -174,8 +174,6 @@ var VimeoPlayer = function (data) {
             }.bind(self));
         };
 
-        self.init();
-
         self.load = function (data) {
             self.videoId = data.id;
             self.videoLength = data.seconds;
@@ -217,6 +215,8 @@ var VimeoPlayer = function (data) {
         self.setVolume = function (vol) {
             self.player.api("setVolume", vol);
         };
+
+        self.init();
     });
 };
 
@@ -282,8 +282,6 @@ var VimeoFlashPlayer = function (data) {
         });
     };
 
-    self.init();
-
     self.load = function (data) {
         self.videoId = data.id;
         self.videoLength = data.seconds;
@@ -323,6 +321,8 @@ var VimeoFlashPlayer = function (data) {
     self.setVolume = function (vol) {
         self.player.api_setVolume(vol);
     };
+
+    self.init();
 };
 
 var DailymotionPlayer = function (data) {

--- a/www/assets/js/player.js
+++ b/www/assets/js/player.js
@@ -468,6 +468,11 @@ var SoundcloudPlayer = function (data) {
         self.videoLength = data.seconds;
         if(self.player && self.player.load) {
             self.player.load(data.id, { auto_play: true });
+            var soundcloudNeedsToFuckingFixTheirPlayer = function () {
+                self.setVolume(VOLUME);
+                self.player.unbind(SC.Widget.Events.PLAY_PROGRESS);
+            };
+            self.player.bind(SC.Widget.Events.PLAY_PROGRESS, soundcloudNeedsToFuckingFixTheirPlayer);
         }
     };
 

--- a/www/assets/js/player.js
+++ b/www/assets/js/player.js
@@ -105,6 +105,20 @@ var YouTubePlayer = function (data) {
         if(self.player && self.player.seekTo)
             self.player.seekTo(time, true);
     };
+
+    self.getVolume = function () {
+        if (!self.player || !self.player.getVolume || !self.player.isMuted) {
+            return NaN;
+        }
+
+        return self.player.isMuted() ? 0 : self.player.getVolume()/100;
+    };
+
+    self.setVolume = function (vol) {
+        if (self.player && self.player.setVolume) {
+            self.player.setVolume(vol * 100);
+        }
+    };
 };
 
 var VimeoPlayer = function (data) {


### PR DESCRIPTION
This feature reads the volume level of the current player before transitioning to a new video, to prevent jarring changes in volume when the player changes e.g. from YouTube to Soundcloud.  Furthermore, the volume is saved in `localStorage` and persists.

Known, unfixable issue with Soundcloud: Soundcloud's volume cannot be changed until playback begins.  Because of this, it is possible that a short (< 1 second) clip might play at maximum volume before the volume is set.  How they managed to screw this up is beyond me.
