### PR TITLE
Add hitbox support

### DIFF
--- a/lib/get-info.js
+++ b/lib/get-info.js
@@ -910,7 +910,21 @@ var Getters = {
                 Logger.errlog.log("Unknown error for Google+ ID " + id + ": " + e.stack);
             }
         });
-    }
+    },
+
+    /* hitbox.tv */
+    hb: function (id, callback) {
+        var m = id.match(/([\w-]+)/);
+        if (m) {
+            id = m[1];
+        } else {
+            callback("Invalid ID", null);
+            return;
+        }
+        var title = "Hitbox.tv - " + id;
+        var media = new Media(id, title, "--:--", "hb");
+        callback(false, media);
+    },
 };
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -238,6 +238,8 @@
                 return "https://docs.google.com/file/d/" + id;
             case "fi":
                 return id;
+            case "hb":
+                return "http://hitbox.tv/" + id;
             default:
                 return "";
         }
@@ -252,6 +254,7 @@
             case "cu":
             case "im":
             case "jw":
+            case "hb":
                 return true;
             default:
                 return false;

--- a/www/js/player.js
+++ b/www/js/player.js
@@ -1044,6 +1044,59 @@ function FilePlayer(data) {
     }
 };
 
+var HitboxPlayer = function (data) {
+    var self = this;
+    self.videoId = data.id;
+    self.videoLength = data.seconds;
+    self.init = function () {
+        if (location.protocol.match(/^https/)) {
+            var div = makeAlert("Security Policy",
+                "You are currently connected via HTTPS but " +
+                "Hitbox only supports plain HTTP.  Due to browser " +
+                "security policy, the embed player cannot be loaded.  " +
+                "In order to watch the video, you must visit this page " +
+                "from its plain HTTP URL (your websocket will still be " +
+                "secured with HTTPS).  Please complain to Hitbox about this.",
+                "alert-danger");
+            div.addClass("embed-responsive-item");
+            removeOld(div);
+            return;
+        }
+
+        var iframe = $("<iframe/>")
+            .attr("src", "http://hitbox.tv/embed/" + self.videoId)
+            .attr("webkitAllowFullScreen", "")
+            .attr("mozallowfullscreen", "")
+            .attr("allowFullScreen", "");
+
+        if (USEROPTS.wmode_transparent)
+            iframe.attr("wmode", "transparent");
+
+        removeOld(iframe);
+        self.player = iframe;
+    };
+
+    self.load = function (data) {
+        self.videoId = data.id;
+        self.videoLength = data.seconds;
+        self.init();
+    };
+
+    self.pause = function () { };
+
+    self.play = function () { };
+
+    self.getTime = function () { };
+
+    self.seek = function () { };
+
+    self.getVolume = function () { };
+
+    self.setVolume = function () { };
+
+    self.init();
+};
+
 function handleMediaUpdate(data) {
     // Don't update if the position is past the video length, but
     // make an exception when the video length is 0 seconds
@@ -1142,7 +1195,8 @@ var constructors = {
     "cu": CustomPlayer,
     "rt": RTMPPlayer,
     "rv": FilePlayer,
-    "fi": FilePlayer
+    "fi": FilePlayer,
+    "hb": HitboxPlayer
 };
 
 function loadMediaPlayer(data) {

--- a/www/js/util.js
+++ b/www/js/util.js
@@ -47,6 +47,8 @@ function formatURL(data) {
             return "https://docs.google.com/file/d/" + data.id;
         case "fi":
             return data.id;
+        case "hb":
+            return "http://hitbox.tv/" + data.id;
         default:
             return "#";
     }
@@ -1303,6 +1305,13 @@ function parseMediaLink(url) {
         return {
             id: m[1] + "_" + m[2] + "_" + m[3],
             type: "gp"
+        };
+    }
+
+    if ((m = url.match(/hitbox\.tv\/([^\?&#]+)/))) {
+        return {
+            id: m[1],
+            type: "hb"
         };
     }
 


### PR DESCRIPTION
Known limitation: doesn't work if the page is loaded over HTTPS, since Hitbox is HTTP only (well, actually, `www.hitbox.tv` does respond to HTTPS, but it immediately redirects to plain HTTP, which still violates browser security policy for mixed active content).
