### PR TITLE
Allow canvas elements through the XSS filter

### DIFF
--- a/lib/xss.js
+++ b/lib/xss.js
@@ -4,6 +4,7 @@ var sanitizeHTML = require("sanitize-html");
 // See https://github.com/punkave/sanitize-html
 const ALLOWED_TAGS = [
     "button",
+    "canvas",
     "center",
     "details",
     "font",


### PR DESCRIPTION
They were allowed before the upgrade to sanitize-html and pose little threat.
