### PR TITLE
Sanitized output of channel name in invalid channel

### DIFF
--- a/lib/web/webserver.js
+++ b/lib/web/webserver.js
@@ -15,6 +15,7 @@ var static = require("serve-static");
 var morgan = require("morgan");
 var session = require("../session");
 var csrf = require("./csrf");
+var XSS = require("../xss");
 
 const LOG_FORMAT = ':real-address - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"';
 morgan.token('real-address', function (req) { return req._ip; });
@@ -76,7 +77,7 @@ function redirectHttp(req, res) {
 function handleChannel(req, res) {
     if (!$util.isValidChannelName(req.params.channel)) {
         res.status(404);
-        res.send("Invalid channel name '" + req.params.channel + "'");
+        res.send("Invalid channel name '" + XSS.sanitizeText(req.params.channel) + "'");
         return;
     }
 


### PR DESCRIPTION
Example request ([link](http://cytu.be/r/%3Cimg%20src=%60%60%20onerror=alert%28%27xxs%27%29%3E))

```
http://cytu.be/r/%3Cimg%20src=%60%60%20onerror=alert%28%27xxs%27%29%3E
```

This does nothing on Chrome as it triggers the XSS auditor, however on Firefox this does trigger the alert.
