### PR TITLE
Update chat antiflood limit

### DIFF
--- a/lib/channel/chat.js
+++ b/lib/channel/chat.js
@@ -24,7 +24,7 @@ const TYPE_PM = {
 
 // Limit to 10 messages/sec
 const MIN_ANTIFLOOD = {
-    burst: 10,
+    burst: 20,
     sustained: 10
 };
 

--- a/lib/channel/chat.js
+++ b/lib/channel/chat.js
@@ -257,7 +257,8 @@ ChatModule.prototype.processChatMsg = function (user, data) {
     var msgobj = this.formatMessage(user.getName(), data);
     var antiflood = MIN_ANTIFLOOD;
     if (this.channel.modules.options &&
-        this.channel.modules.options.get("chat_antiflood")) {
+        this.channel.modules.options.get("chat_antiflood") &&
+        user.account.effectiveRank < 2) {
 
         antiflood = this.channel.modules.options.get("chat_antiflood_params");
     }

--- a/lib/channel/chat.js
+++ b/lib/channel/chat.js
@@ -22,10 +22,10 @@ const TYPE_PM = {
     meta: "object,optional"
 };
 
-const DEFAULT_ANTIFLOOD = {
-    burst: 4,
-    sustained: 1,
-    cooldown: 4
+// Limit to 10 messages/sec
+const MIN_ANTIFLOOD = {
+    burst: 10,
+    sustained: 10
 };
 
 function ChatModule(channel) {
@@ -198,8 +198,8 @@ ChatModule.prototype.handlePm = function (user, data) {
         return;
     }
 
-    if (user.chatLimiter.throttle(DEFAULT_ANTIFLOOD)) {
-        user.socket.emit("cooldown", 1000 / DEFAULT_ANTIFLOOD.sustained);
+    if (user.chatLimiter.throttle(MIN_ANTIFLOOD)) {
+        user.socket.emit("cooldown", 1000 / MIN_ANTIFLOOD.sustained);
         return;
     }
 
@@ -255,7 +255,7 @@ ChatModule.prototype.processChatMsg = function (user, data) {
     }
 
     var msgobj = this.formatMessage(user.getName(), data);
-    var antiflood = DEFAULT_ANTIFLOOD;
+    var antiflood = MIN_ANTIFLOOD;
     if (this.channel.modules.options &&
         this.channel.modules.options.get("chat_antiflood")) {
 

--- a/lib/channel/opts.js
+++ b/lib/channel/opts.js
@@ -39,6 +39,11 @@ OptionsModule.prototype.load = function (data) {
             }
         }
     }
+
+    this.opts.chat_antiflood_params.burst = Math.min(20,
+            this.opts.chat_antiflood_params.burst);
+    this.opts.chat_antiflood_params.sustained = Math.min(10,
+            this.opts.chat_antiflood_params.sustained);
 };
 
 OptionsModule.prototype.save = function (data) {
@@ -216,10 +221,14 @@ OptionsModule.prototype.handleSetOptions = function (user, data) {
             b = 1;
         }
 
+        b = Math.min(20, b);
+
         var s = parseFloat(data.chat_antiflood_params.sustained);
         if (isNaN(s) || s <= 0) {
             s = 1;
         }
+
+        s = Math.min(10, s);
 
         var c = b / s;
         this.opts.chat_antiflood_params = {


### PR DESCRIPTION
As mentioned previously, allowing channels/moderators to have no limit is not really a good idea, however applying the channel limit to moderators and having a default limit that is relatively slow is not what users want.

The compromise is this:
- Channels must set a burst count <= 20 and a sustained rate <= 10 messages/sec
- If channel rate limiting is disabled, a global limit of 10 messages/sec (with 10 burst) is enforced
- Channel limits are not applied to moderators, instead the global limit from the previous point is used.
- The global limit, not the channel limit, is applied to PMs
