### PR TITLE
Change chat's font to Consolas

### DIFF
--- a/www/css/cytube.css
+++ b/www/css/cytube.css
@@ -42,6 +42,7 @@
     overflow-x: hidden;
     overflow-y: scroll;
     margin-bottom: 0;
+    font-family: Consolas;
 }
 
 #chatline, #guestlogin > input, #guestlogin > .input-group-addon {


### PR DESCRIPTION
This prevents guests "stealing" other users name by replacing lowercase l with uppercase I and vice versa.
Courier is another alternative font that will fix this issue.
