### PR TITLE
fix playlist scrolling performance in chrome

### DIFF
--- a/www/css/cytube.css
+++ b/www/css/cytube.css
@@ -156,6 +156,7 @@
     list-style: none outside none;
     max-height: 500px;
     overflow-y: auto;
+    transform: translateZ(0);
 }
 
 

--- a/www/css/cytube.css
+++ b/www/css/cytube.css
@@ -151,8 +151,9 @@
 }
 
 .videolist {
+    padding: 0;
+    margin: 0;
     list-style: none outside none;
-    margin-left: 0;
     max-height: 500px;
     overflow-y: auto;
 }
@@ -167,10 +168,6 @@
     background-image: url(/img/stripe-diagonal.png);
 }
 
-.videolist {
-    padding: 0;
-    margin: 0;
-}
 
 #queue > li:last-child {
     border-bottom-width: 0;


### PR DESCRIPTION
In chrome (and probably other webkit/blink-based browsers) the scrolling performance of the playlist is awful when there are a lot of items in the playlist and the individual item buttons are displayed. This change forces the playlist to be on its own compositing layer, improving performance significantly.
