### PR TITLE
more than one Play click deleted a playlist item

### DIFF
--- a/src/channel/playlist.js
+++ b/src/channel/playlist.js
@@ -646,7 +646,7 @@ PlaylistModule.prototype.handleJumpTo = function (user, data) {
         this.startPlayback();
         this.channel.logger.log("[playlist] " + user.getName() + " skipped " + title);
 
-        if (old && old.temp) {
+        if (old && old.temp && old !== to) {
             this._delete(old.uid);
         }
     }


### PR DESCRIPTION
If two people tried to play the same playlist item, before the playlist updated, it would delete instead of playing.
The same would also happen if the play button was double-clicked instead of single-clicked.
Also, the active item's play button functioned as a delete button.

Fully tested. Still removes the item (if it was added as temporary) when it finishes playing, or if the play button of a _different_ item is clicked.
