### PR TITLE
Use absolute path for counters.log

### DIFF
--- a/src/counters.js
+++ b/src/counters.js
@@ -1,5 +1,6 @@
 var Logger = require('./logger');
-var counterLog = new Logger.Logger('counters.log');
+var path = require('path');
+var counterLog = new Logger.Logger(path.resolve(__dirname, '..', 'counters.log'));
 import os from 'os';
 import io from 'socket.io';
 import Socket from 'socket.io/lib/socket';


### PR DESCRIPTION
Puts it in line with the other uses of `Logger.Logger`. Allows running outside of pwd.
