### PR TITLE
Prevent rendering of <iframes> and <objects> in the error message …

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -394,7 +394,7 @@ function queue(pos, src) {
             if (data.id == null || data.type == null) {
                 makeAlert("Error", "Failed to parse link " + link +
                           ".  Please check that it is correct",
-                          "alert-danger")
+                          "alert-danger", true)
                     .insertAfter($("#addfromurl"));
             } else {
                 emitQueue.push({

--- a/www/js/util.js
+++ b/www/js/util.js
@@ -1,4 +1,4 @@
-function makeAlert(title, text, klass) {
+function makeAlert(title, text, klass, textOnly) {
     if(!klass) {
         klass = "alert-info";
     }
@@ -7,8 +7,9 @@ function makeAlert(title, text, klass) {
 
     var al = $("<div/>").addClass("alert")
         .addClass(klass)
-        .html(text)
         .appendTo(wrap);
+    textOnly ? al.text(text) : al.html(text) ;
+
     $("<br/>").prependTo(al);
     $("<strong/>").text(title).prependTo(al);
     $("<button/>").addClass("close pull-right").html("&times;")


### PR DESCRIPTION
…when attempting to queue them as supported host links instead of custom embeds.

I thought about just moving the parse failure message handling to queueMessage, but that quickly turned into a minefield of pain. This gets the job done for now.
