### PR TITLE
Use explicit GitHub URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "socket.io": "^1.4.0",
     "socket.io-redis": "^1.0.0",
     "source-map-support": "^0.4.0",
-    "status-message-polyfill": "calzoneman/status-message-polyfill",
+    "status-message-polyfill": "git://github.com/calzoneman/status-message-polyfill",
     "uuid": "^2.0.1",
     "yamljs": "^0.1.6"
   },


### PR DESCRIPTION
The dependency on status-message-polyfill appeared to be missing part of its URL, judging by the rest of the file. Changing this line allowed me to build and install on a self-hosted server.
