### PR TITLE
Send the right account object on user login

### DIFF
--- a/src/io/ioserver.js
+++ b/src/io/ioserver.js
@@ -229,7 +229,7 @@ function handleConnection(sock) {
             db.recordVisit(ip, user.getName());
             user.socket.emit("rank", user.account.effectiveRank);
             user.setFlag(Flags.U_LOGGED_IN);
-            user.emit("login", account);
+            user.emit("login", user.account);
             Logger.syslog.log(ip + " logged in as " + user.getName());
             user.setFlag(Flags.U_READY);
         });


### PR DESCRIPTION
Don't send a null "account" object, instead use user.account. Was getting an error about this when trying to log in to my admin account on a self-hosted installation.
