### PR TITLE
Change fallback voteskip ratio to .5 from 0

### DIFF
--- a/src/channel/opts.js
+++ b/src/channel/opts.js
@@ -116,7 +116,7 @@ OptionsModule.prototype.handleSetOptions = function (user, data) {
         if (isNaN(ratio) || ratio < 0) {
             user.socket.emit("validationError", {
                 target: "#cs-voteskip_ratio",
-                message: "Input must be a number 0 or greater. 1.0 is 100%."
+                message: `Input must be a number 0 or greater, not "${data.voteskip_ratio}"`
             });
         } else {
             this.opts.voteskip_ratio = ratio;

--- a/src/channel/opts.js
+++ b/src/channel/opts.js
@@ -114,10 +114,17 @@ OptionsModule.prototype.handleSetOptions = function (user, data) {
     if ("voteskip_ratio" in data) {
         var ratio = parseFloat(data.voteskip_ratio);
         if (isNaN(ratio) || ratio < 0) {
-            ratio = 0.5;
+            user.socket.emit("validationError", {
+                target: "#cs-voteskip_ratio",
+                message: "Input must be a number 0 or greater. 1.0 is 100%."
+            });
+        } else {
+            this.opts.voteskip_ratio = ratio;
+            sendUpdate = true;
+            user.socket.emit("validationPassed", {
+                target: "#cs-voteskip_ratio"
+            });
         }
-        this.opts.voteskip_ratio = ratio;
-        sendUpdate = true;
     }
 
     if ("afk_timeout" in data) {

--- a/src/channel/opts.js
+++ b/src/channel/opts.js
@@ -114,7 +114,7 @@ OptionsModule.prototype.handleSetOptions = function (user, data) {
     if ("voteskip_ratio" in data) {
         var ratio = parseFloat(data.voteskip_ratio);
         if (isNaN(ratio) || ratio < 0) {
-            ratio = 0;
+            ratio = 0.5;
         }
         this.opts.voteskip_ratio = ratio;
         sendUpdate = true;


### PR DESCRIPTION
moderators might make a mistake changing the skip ratio, causing it to fall back to 0% and allowing users to "skiptrain" before it is fixed