### PR TITLE
Fuck off Google

### DIFF
--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -44,7 +44,9 @@ html(lang="en")
                 span#usercount.pointer Not Connected
                 span#modflair.label.label-default.pull-right.pointer Name Color
               #userlist
+              <!--googleoff: snippet-->
               #messagebuffer.linewrap
+              <!--googleon: snippet-->
               input#chatline.form-control(type="text", maxlength="240", style="display: none")
               #guestlogin.input-group
                 span.input-group-addon Guest login


### PR DESCRIPTION
This will prevent Google from using the contents of the `#messagebuffer` as snippet text in it's search index