### PR TITLE
make ACP use HTTPS only if it is enabled

### DIFF
--- a/src/web/acp.js
+++ b/src/web/acp.js
@@ -28,7 +28,7 @@ function checkAdmin(cb) {
  */
 function handleAcp(req, res, user) {
     var sio;
-    if (req.secure || req.header("x-forwarded-proto") === "https") {
+    if ( Config.get("https.enabled") && (req.secure || req.header("x-forwarded-proto") === "https") ) {
         sio = Config.get("https.domain") + ":" + Config.get("https.default-port");
     } else {
         sio = Config.get("io.domain") + ":" + Config.get("io.default-port");


### PR DESCRIPTION
This change really just clarifies things a bit for the server. Only generate a HTTPS link if you tell the server you are using HTTPS explicitly.

If you use HTTPS already websockets will refuse to be anything besides WSS.
If you use HTTP, websockets can use WSS but chances are you don't have that setup and it wouldn't work.