### PR TITLE
Make it possible to trust all proxies in config

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -253,3 +253,9 @@ twitch-client-id: null
 
 poll:
   max-options: 50
+
+# Proxy trust settings 
+# set trust-all to true if you know anyone who is capable of connecting to your server is
+# trustworthy (for example if you proxy into a private network)
+proxy:
+  trust-all: false

--- a/src/io/ioserver.js
+++ b/src/io/ioserver.js
@@ -184,6 +184,7 @@ function ipForwardingMiddleware(webConfig) {
     }
 
     function isTrustedProxy(ip) {
+        if (Config.get("proxy.trust-all") === true) { return true; }
         return webConfig.getTrustedProxies().indexOf(ip) >= 0;
     }
 


### PR DESCRIPTION
It seems the WebConfig section for specifying trusted proxies is still hardcoded. This presents a problem because trusting proxies is the first step to recognizing the validity of X-Forwarded-For

There are times when one wants to trust all proxies that connect to cytube, i.e. in a completely private network where the only connections come through a reverse proxy.

This PR gives the ability to tell the server that.