### PR TITLE
Upgrade babel preset for node 6, add async transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ addons:
 env:
   - CXX="g++-4.8"
 node_js:
+  - "8"
   - "7"
   - "6"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+2017-06-20
+==========
+
+The latest commit drops support for node.js versions below 6 (the [current
+LTS](https://github.com/nodejs/LTS#lts-schedule1)).  This is to allow the babel
+preset to avoid generating inefficient code to polyfill ES2015+ features that
+are now implemented in the node.js core.
+
+New versions of node.js can be downloaded from the [node.js
+website](https://nodejs.org/en/download/), if they are not already available in
+your distribution's package manager.
+
 2017-03-20
 ==========
 

--- a/package.json
+++ b/package.json
@@ -2,18 +2,13 @@
   "author": "Calvin Montgomery",
   "name": "CyTube",
   "description": "Online media synchronizer and chat",
-  "version": "3.38.3",
+  "version": "3.39.0",
   "repository": {
     "url": "http://github.com/calzoneman/sync"
   },
   "license": "MIT",
   "dependencies": {
     "@calzoneman/jsli": "^1.0.1",
-    "babel-cli": "^6.1.4",
-    "babel-core": "^6.1.4",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-es2015-destructuring": "^6.3.15",
-    "babel-preset-es2015": "^6.1.4",
     "bcrypt": "^0.8.5",
     "bluebird": "^2.10.1",
     "body-parser": "^1.14.0",
@@ -62,7 +57,12 @@
     "integration-test": "mocha --recursive integration_test"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-preset-env": "^1.5.2",
     "coffee-script": "^1.9.2",
     "flow-bin": "^0.43.0",
     "mocha": "^3.2.0",
@@ -70,15 +70,17 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      [
+        "env",
+        {
+          "targets": {
+            "node": "6"
+          }
+        }
+      ]
     ],
     "plugins": [
-      [
-        "transform-es2015-destructuring",
-        {
-          "loose": true
-        }
-      ],
+      "transform-async-to-generator",
       "add-module-exports",
       "transform-flow-strip-types"
     ]


### PR DESCRIPTION
The `es2015` preset transforms all ES2015 features into ES5, resulting in a lot of unnecessary polyfills for features that have been in node.js core for a while now.  Upgrading to https://github.com/babel/babel-preset-env/ targeting node.js 6 (current LTS).