### PR TITLE
Add breaking spaces into footer

### DIFF
--- a/templates/footer.pug
+++ b/templates/footer.pug
@@ -2,7 +2,7 @@ mixin footer
   footer#footer
     .container
       p.text-muted.credit.
-        Copyright &copy; 2013-2018 Calvin Montgomery&nbsp;&middot;&nbsp;<a href="https://github.com/calzoneman/sync" target="_blank" rel="noreferrer noopener">GitHub</a>&nbsp;&middot;&nbsp;<a href="/contact" target="_blank">Contact</a>&nbsp;&middot;&nbsp;<a href="https://github.com/calzoneman/sync/wiki" target="_blank" rel="noopener noreferrer">Wiki</a>
+        Copyright &copy; 2013-2018 Calvin Montgomery&nbsp;&middot; <a href="https://github.com/calzoneman/sync" target="_blank" rel="noreferrer noopener">GitHub</a>&nbsp;&middot; <a href="/contact" target="_blank">Contact</a>&nbsp;&middot; <a href="https://github.com/calzoneman/sync/wiki" target="_blank" rel="noopener noreferrer">Wiki</a>
   script(src="/js/jquery-1.11.0.min.js")
   // Must be included before jQuery-UI since jQuery-UI overrides jQuery.fn.button
   // I should really abandon this crap one day


### PR DESCRIPTION
On small mobile devices, the non-breaking spaces in the footer cause the links to overflow the container. (It's not so much of a problem with this version of the code, but the official website has an extra PayPal link which just pushes it over the edge.) This change replaces the non-breaking spaces after each middle dot with a normal space. This way, each middle dot stays with the link before it. (I chose this because I think it looks weird to have a line start with a dot.)