### PR TITLE
removed code that requires application/x-mpegURL to be live for custo…

### DIFF
--- a/src/custom-media.js
+++ b/src/custom-media.js
@@ -30,8 +30,7 @@ const SOURCE_CONTENT_TYPES = new Set([
 ]);
 
 const LIVE_ONLY_CONTENT_TYPES = new Set([
-    'application/dash+xml',
-    'application/x-mpegURL'
+    'application/dash+xml'
 ]);
 
 export function lookup(url, opts) {

--- a/test/custom-media.js
+++ b/test/custom-media.js
@@ -90,15 +90,6 @@ describe('custom-media', () => {
             assert.throws(() => validate(invalid), /URL protocol must be HTTPS/);
         });
 
-        it('rejects non-live HLS', () => {
-            invalid.live = false;
-            invalid.sources[0].contentType = 'application/x-mpegURL';
-
-            assert.throws(
-                () => validate(invalid),
-                /contentType "application\/x-mpegURL" requires live: true/
-            );
-        });
     });
 
     describe('#validateSources', () => {


### PR DESCRIPTION
As per: [Feature Request] Support for HLS VoD Streams #767

I removed the lines that blocked the HLS stream from being added non-live. The only issue is that on my phone it shows a button that you have to click to start playback on android.  After clicking the button it does sync up as expected. 