### PR TITLE
add autoplay attribute to custom embed iframe tag, so autoplay works

### DIFF
--- a/player/embed.coffee
+++ b/player/embed.coffee
@@ -59,6 +59,7 @@ window.EmbedPlayer = class EmbedPlayer extends Player
             iframe = $('<iframe/>').attr(
                 src: embed.src
                 frameborder: '0'
+                allow: 'autoplay'
                 allowfullscreen: '1'
             )
 


### PR DESCRIPTION
calzone said i should make a pull request. so here it is.
it would be great if 'allow="autoplay"' attribute is added to the generated iframe for custom embeds.
so autoplay works as expected.