### PR TITLE
Replaced "display: none" check logic

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -817,7 +817,7 @@ $("#cs-emotes-import").click(function () {
 
 var toggleUserlist = function () {
     var direction = !USEROPTS.layout.match(/synchtube/) ? "glyphicon-chevron-right" : "glyphicon-chevron-left"
-    if ($("#userlist").css("display") === "none") {
+    if ($("#userlist")[0].style.display === "none") {
         $("#userlist").show();
         $("#userlisttoggle").removeClass(direction).addClass("glyphicon-chevron-down");
     } else {


### PR DESCRIPTION
JQuery queries using getComputedStyle, which makes it impossible to change userlist behavior using CSS. This replaces the check with a direct style="" value check so the JS does not trip up if any CSS customizations to the list visibility were made.

Example: if `#userlist` is set to `display: block !important` in the custom CSS, the toggle will break and won't toggle between `none` and `block`. Implementing custom CSS leveraging this state change thus is not possible.