### PR TITLE
Replace userlist visibility check logic

### DIFF
--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -6,7 +6,7 @@ html(lang="en")
     link(href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css", rel="stylesheet")
     link(rel="stylesheet", href="/css/video-js.css")
     link(rel="stylesheet", href="/css/videojs-resolution-switcher.css")
-  body(class=loggedIn ? 'logged-in' : 'guest')
+  body
     #wrap
       nav.navbar.navbar-inverse.navbar-fixed-top(role="navigation")
         include nav

--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -6,7 +6,7 @@ html(lang="en")
     link(href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css", rel="stylesheet")
     link(rel="stylesheet", href="/css/video-js.css")
     link(rel="stylesheet", href="/css/videojs-resolution-switcher.css")
-  body
+  body(class=loggedIn ? 'logged-in' : 'guest')
     #wrap
       nav.navbar.navbar-inverse.navbar-fixed-top(role="navigation")
         include nav

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -15,7 +15,7 @@ $(window).focus(CyTube.ui.onPageFocus).blur(CyTube.ui.onPageBlur);
 $(".modal").focus(CyTube.ui.onPageFocus);
 
 $("#togglemotd").click(function () {
-    var hidden = $("#motd").css("display") === "none";
+    var hidden = $("#motd")[0].style.display === "none";
     $("#motd").toggle();
     if (hidden) {
         $("#togglemotd").find(".glyphicon-plus")

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -817,7 +817,7 @@ $("#cs-emotes-import").click(function () {
 
 var toggleUserlist = function () {
     var direction = !USEROPTS.layout.match(/synchtube/) ? "glyphicon-chevron-right" : "glyphicon-chevron-left"
-    if ($("#userlist").css("display") === "none") {
+    if ($("#userlist")[0].style.display === "none") {
         $("#userlist").show();
         $("#userlisttoggle").removeClass(direction).addClass("glyphicon-chevron-down");
     } else {


### PR DESCRIPTION
>JQuery queries using getComputedStyle, which makes it impossible to change userlist behavior using CSS. This replaces the check with a direct style="" value check so the JS does not trip up if any CSS customizations to the list visibility were made.
>
>Example: if `#userlist` is set to `display: block !important` in the custom CSS, the toggle will break and won't toggle between `none` and `block`. Implementing custom CSS leveraging this state change thus is not possible.
-- Algoinde