### PR TITLE
Explicitly use UTF8 encoding for media metadata table

### DIFF
--- a/src/database/tables.js
+++ b/src/database/tables.js
@@ -147,6 +147,7 @@ export async function initTables() {
         // The types of id and type are chosen for compatibility
         // with the existing channel_libraries table.
         // TODO in the future schema, revisit the ID layout for different media types.
+        t.charset('utf8');
         t.string('id', 255).notNullable();
         t.string('type', 2).notNullable();
         t.text('metadata').notNullable();


### PR DESCRIPTION
This resolves the ER_TOO_LONG_KEY error on creation of the media_metadata_cache table because databases that default to full 4-byte `utf8mb4` encoding make the `VARCHAR(255)` `id` column larger than the maximum supported key binary length of 767 bytes by MySQL and MariaDB RDBMS's.

Resolves #860 