### PR TITLE
adjust sendUserMeta rank comparison

### DIFF
--- a/src/channel/channel.js
+++ b/src/channel/channel.js
@@ -554,7 +554,7 @@ Channel.prototype.sendUserMeta = function (users, user, minrank) {
     var self = this;
     var userdata = self.packUserData(user);
     users.filter(function (u) {
-        return typeof minrank !== "number" || u.account.effectiveRank > minrank;
+        return typeof minrank !== "number" || u.account.effectiveRank >= minrank;
     }).forEach(function (u) {
         if (u.account.globalRank >= 255)  {
             u.socket.emit("setUserMeta", {


### PR DESCRIPTION
Right now, those who use mute and shadowmute seem to miss out on the setUserMeta frame if their rank is the same as the minimum permission for muting users. This should fix it. Doesn't seem to break anything, but will now include users with a rank of -1 when -1 is passed as minrank for actions such as unmute -- just something to note in case that isn't intended for whatever reason.