### PR TITLE
Support enabling custom media subtitle by default

### DIFF
--- a/docs/custom-media.md
+++ b/docs/custom-media.md
@@ -119,6 +119,8 @@ Each text track entry is a JSON object with the following keys:
     [`text/vtt`](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API).
   * `name`: A name for the text track.  This is displayed in the menu for the
     viewer to select a text track.
+  * `default`: Enable track by default.  Optional boolean attribute to enable
+    a subtitle track to the user by default.
 
 **Important note regarding text tracks and CORS:**
 
@@ -148,7 +150,8 @@ for more information about setting this header.
         {
           "url": "https://example.com/subtitles.vtt",
           "contentType": "text/vtt",
-          "name": "English Subtitles"
+          "name": "English Subtitles",
+          "default": true
         }
       ]
     }

--- a/player/videojs.coffee
+++ b/player/videojs.coffee
@@ -96,12 +96,16 @@ window.VideoJSPlayer = class VideoJSPlayer extends Player
             if data.meta.textTracks
                 data.meta.textTracks.forEach((track) ->
                     label = track.name
-                    $('<track/>').attr(
+                    attrs =
                         src: track.url
                         kind: 'subtitles'
                         type: track.type
                         label: label
-                    ).appendTo(video)
+
+                    if track.default? and track.default
+                        attrs.default = ''
+
+                    $('<track/>').attr(attrs).appendTo(video)
                 )
 
             @player = videojs(video[0],

--- a/src/custom-media.js
+++ b/src/custom-media.js
@@ -209,6 +209,7 @@ function validateTextTracks(textTracks) {
     if (!Array.isArray(textTracks))
         throw new ValidationError('textTracks must be a list');
 
+    let default_count = 0;
     for (let track of textTracks) {
         if (typeof track.url !== 'string')
             throw new ValidationError('text track URL must be a string');
@@ -223,6 +224,15 @@ function validateTextTracks(textTracks) {
             throw new ValidationError('text track name must be a string');
         if (!track.name)
             throw new ValidationError('text track name must be nonempty');
+
+        if (typeof track.default !== 'undefined') {
+            if (default_count > 0)
+                throw new ValidationError('only one default text track is allowed');
+            else if (typeof track.default !== 'boolean' || track.default !== true)
+                throw new ValidationError('text default attribute must be set to boolean true');
+            else
+                default_count++;
+        }
     }
 }
 


### PR DESCRIPTION
If there's a cleaner way to do the CoffeeScript code instead of copying every attribute twice, let me know.
Tested locally and works as intended.