### PR TITLE
Fix chat width resizing when window is very thin

### DIFF
--- a/www/css/cytube.css
+++ b/www/css/cytube.css
@@ -28,6 +28,11 @@
     padding-right: 5px;
 }
 
+#usercount {
+    white-space: nowrap;
+    flex-grow: 2;
+}
+
 #userlist {
     width: 120px;
     float: left;
@@ -88,6 +93,12 @@
 
     text-align: center;
     font-weight: bold;
+}
+
+#chatheader {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 #chatheader > p, #videowrap-header {
@@ -582,7 +593,7 @@ table td {
 }
 
 #userlisttoggle {
-    padding-top: 2px;
+    padding-bottom: 2px;
 }
 
 .queue_entry {


### PR DESCRIPTION
When the window resized to a small width, the chat header buttons would wrap to the next line, but would inline with the chat box itself making it resize to unreadable widths.
Changing the header to flex with some minor adjustments prevents the inline wrapping thus the chatbox retains it's intended width.