### PR TITLE
removed code that requires application/dash+xml to be live for custom media manifests

### DIFF
--- a/src/custom-media.js
+++ b/src/custom-media.js
@@ -30,10 +30,6 @@ const SOURCE_CONTENT_TYPES = new Set([
     'video/webm'
 ]);
 
-const LIVE_ONLY_CONTENT_TYPES = new Set([
-    'application/dash+xml'
-]);
-
 export function lookup(url, opts) {
     if (!opts) opts = {};
     if (!opts.hasOwnProperty('timeout')) opts.timeout = 10000;
@@ -181,11 +177,6 @@ function validateSources(sources, data) {
         if (!SOURCE_CONTENT_TYPES.has(source.contentType))
             throw new ValidationError(
                 `unacceptable source contentType "${source.contentType}"`
-            );
-
-        if (LIVE_ONLY_CONTENT_TYPES.has(source.contentType) && !data.live)
-            throw new ValidationError(
-                `contentType "${source.contentType}" requires live: true`
             );
 
         if (!SOURCE_QUALITIES.has(source.quality))

--- a/test/custom-media.js
+++ b/test/custom-media.js
@@ -90,15 +90,6 @@ describe('custom-media', () => {
             assert.throws(() => validate(invalid), /URL protocol must be HTTPS/);
         });
 
-        it('rejects non-live DASH', () => {
-            invalid.live = false;
-            invalid.sources[0].contentType = 'application/dash+xml';
-
-            assert.throws(
-                () => validate(invalid),
-                /contentType "application\/dash\+xml" requires live: true/
-            );
-        });
     });
 
     describe('#validateSources', () => {


### PR DESCRIPTION
Tried to base these changes off #768 
I tested and can confirm that MPD VODs work just fine. Removing the live check will allow durations and automatic track progression. First commit to src/custom-media.js might have been _too_ much? I removed `LIVE_ONLY_CONTENT_TYPES` and the validation check entirely since the former would've been empty.