### PR TITLE
Add max chat message length config option

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -128,7 +128,7 @@ max-channels-per-user: 5
 max-accounts-per-ip: 5
 # Minimum number of seconds between guest logins from the same IP
 guest-login-delay: 60
-# Maximum character length of a chat message
+# Maximum character length of a chat message, capped at 1000 characters
 max-chat-message-length: 320
 
 # Allows you to customize the path divider. The /r/ in http://localhost/r/yourchannel

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -129,7 +129,7 @@ max-accounts-per-ip: 5
 # Minimum number of seconds between guest logins from the same IP
 guest-login-delay: 60
 # Maximum character length of a chat message
-max-chat-msg-length: 320
+max-chat-message-length: 320
 
 # Allows you to customize the path divider. The /r/ in http://localhost/r/yourchannel
 # Acceptable characters are a-z A-Z 0-9 _ and -

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -128,6 +128,8 @@ max-channels-per-user: 5
 max-accounts-per-ip: 5
 # Minimum number of seconds between guest logins from the same IP
 guest-login-delay: 60
+# Maximum character length of a chat message
+max-chat-msg-length: 320
 
 # Allows you to customize the path divider. The /r/ in http://localhost/r/yourchannel
 # Acceptable characters are a-z A-Z 0-9 _ and -

--- a/src/channel/chat.js
+++ b/src/channel/chat.js
@@ -162,7 +162,7 @@ ChatModule.prototype.handleChatMsg = function (user, data) {
         return;
     }
 
-    data.msg = data.msg.substring(0, 320);
+    data.msg = data.msg.substring(0, Config.get("max-chat-msg-length"));
 
     // Restrict new accounts/IPs from chatting and posting links
     if (this.restrictNewAccount(user, data)) {
@@ -248,7 +248,7 @@ ChatModule.prototype.handlePm = function (user, data) {
     }
 
 
-    data.msg = data.msg.substring(0, 320);
+    data.msg = data.msg.substring(0, Config.get("max-chat-msg-length"));
     var to = null;
     for (var i = 0; i < this.channel.users.length; i++) {
         if (this.channel.users[i].getLowerName() === data.to) {

--- a/src/channel/chat.js
+++ b/src/channel/chat.js
@@ -162,7 +162,7 @@ ChatModule.prototype.handleChatMsg = function (user, data) {
         return;
     }
 
-    data.msg = data.msg.substring(0, Config.get("max-chat-msg-length"));
+    data.msg = data.msg.substring(0, Config.get("max-chat-message-length"));
 
     // Restrict new accounts/IPs from chatting and posting links
     if (this.restrictNewAccount(user, data)) {
@@ -248,7 +248,7 @@ ChatModule.prototype.handlePm = function (user, data) {
     }
 
 
-    data.msg = data.msg.substring(0, Config.get("max-chat-msg-length"));
+    data.msg = data.msg.substring(0, Config.get("max-chat-message-length"));
     var to = null;
     for (var i = 0; i < this.channel.users.length; i++) {
         if (this.channel.users[i].getLowerName() === data.to) {

--- a/src/config.js
+++ b/src/config.js
@@ -428,6 +428,11 @@ function preprocessConfig(cfg) {
         cfg['channel-storage'] = { type: undefined };
     }
 
+    if (cfg["max-chat-message-length"] > 1000) {
+        LOGGER.warn("Max chat message length was greater than 1000. Setting to 1000.");
+        cfg["max-chat-message-length"] = 1000;
+    }
+
     return cfg;
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -71,6 +71,7 @@ var defaults = {
     "max-channels-per-user": 5,
     "max-accounts-per-ip": 5,
     "guest-login-delay": 60,
+    "max-chat-msg-length": 320,
     aliases: {
         "purge-interval": 3600000,
         "max-age": 2592000000

--- a/src/config.js
+++ b/src/config.js
@@ -71,7 +71,7 @@ var defaults = {
     "max-channels-per-user": 5,
     "max-accounts-per-ip": 5,
     "guest-login-delay": 60,
-    "max-chat-msg-length": 320,
+    "max-chat-message-length": 320,
     aliases: {
         "purge-interval": 3600000,
         "max-age": 2592000000

--- a/src/web/routes/channel.js
+++ b/src/web/routes/channel.js
@@ -29,7 +29,7 @@ export default function initialize(app, ioConfig, chanPath, getBannedChannel) {
         sendPug(res, 'channel', {
             channelName: req.params.channel,
             sioSource: `${socketBaseURL}/socket.io/socket.io.js`,
-            maxMsgLen: Config.get("max-chat-msg-length")
+            maxMsgLen: Config.get("max-chat-message-length")
         });
     });
 }

--- a/src/web/routes/channel.js
+++ b/src/web/routes/channel.js
@@ -1,4 +1,5 @@
 import CyTubeUtil from '../../utilities';
+import Config from '../../config';
 import { sanitizeText } from '../../xss';
 import { sendPug } from '../pug';
 import * as HTTPStatus from '../httpstatus';
@@ -27,7 +28,8 @@ export default function initialize(app, ioConfig, chanPath, getBannedChannel) {
 
         sendPug(res, 'channel', {
             channelName: req.params.channel,
-            sioSource: `${socketBaseURL}/socket.io/socket.io.js`
+            sioSource: `${socketBaseURL}/socket.io/socket.io.js`,
+            maxMsgLen: Config.get("max-chat-msg-length")
         });
     });
 }

--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -46,7 +46,7 @@ html(lang="en")
               #userlist
               #messagebuffer.linewrap
               form(action="javascript:void(0)")
-                input#chatline.form-control(type="text", maxlength=`${maxMsgLen}`, style="display: none")
+                input#chatline.form-control(type="text", maxlength=maxMsgLen, style="display: none")
                 #guestlogin.input-group
                   span.input-group-addon Guest login
                   input#guestname.form-control(type="text", placeholder="Name")

--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -46,7 +46,7 @@ html(lang="en")
               #userlist
               #messagebuffer.linewrap
               form(action="javascript:void(0)")
-                input#chatline.form-control(type="text", maxlength="320", style="display: none")
+                input#chatline.form-control(type="text", maxlength=`${maxMsgLen}`, style="display: none")
                 #guestlogin.input-group
                   span.input-group-addon Guest login
                   input#guestname.form-control(type="text", placeholder="Name")


### PR DESCRIPTION
Just thought it would be nice. I wanted to increase the max message length of an instance I stood up recently, so that it could be closer to IRC message length. Decided to refactor it into an option instead of just changing the hard coded values.