### PR TITLE
Add player integration code removed from the dailymotion js sdk

### DIFF
--- a/player/dailymotion.coffee
+++ b/player/dailymotion.coffee
@@ -18,7 +18,12 @@ window.DailymotionPlayer = class DailymotionPlayer extends Player
             if quality != 'auto'
                 params.quality = quality
 
-            @dm = DM.player('ytapiplayer',
+            @element = DM.$('ytapiplayer')
+            if not @element or @element.nodeType != Node.ELEMENT_NODE
+                throw new Error("Invalid player element in DailymotionPlayer(), requires an existing HTML element: " + @element)
+            if DM.Player._INSTANCES[@element.id] != undefined
+                @element = DM.Player.destroy(@element.id)
+            @dm = DM.Player.create(@element,
                 video: data.id
                 width: parseInt(VWIDTH, 10)
                 height: parseInt(VHEIGHT, 10)


### PR DESCRIPTION
The broken dailymotion player described in https://github.com/calzoneman/sync/issues/980 was caused by Dailymotion removing direct player creation support from their js SDK. They’d set up a method to remove it a while ago, which they turned on with their [commit 75b4102](https://github.com/dailymotion/dailymotion-sdk-js/commit/75b410229aa10467026a53cc5778fde66f1e9be5). The js SDK, documented [here](https://developers.dailymotion.com/sdk/platform-sdk/javascript/), is loaded from https://api.dmcdn.net/all.js by sync & other projects. The SDK’s github readme currently says:
 
> ⚠️ WARNING: We no longer support this SDK for Player integration on web environments. It can be used for interaction with the [Platform API](https://developers.dailymotion.com/api/platform-api/) only. The Player should be embedded using the new default Player integration methods, info can be found [here](https://developers.dailymotion.com/sdk/player-sdk/web).

The new integration method they point to there seems to demand [making a dailymotion account, configuring a custom player w/ a unique ID, and loading their scripts based on that ID](https://developers.dailymotion.com/guides/getting-started-with-web-sdk/) . This is a can of worms, and it's not clear how this could work for sync in general.

Fortunately, it’s still possible to create a Dailymotion player with their js SDK’s object interface, instead of the functional interface that vanished when they decided to “Sunset player API v2". This PR does so to get Dailymotion sync support working again.