### PR TITLE
Fix #994

### DIFF
--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -46,7 +46,7 @@ html(lang="en")
               #userlist
               #messagebuffer.linewrap
               form(action="javascript:void(0)")
-                input#chatline.form-control(type="text", maxlength=maxMsgLen, style="display: none")
+                input#chatline.form-control(type="text", maxlength=maxMsgLen, style="display: none", data-bwignore="1")
                 #guestlogin.input-group
                   span.input-group-addon Guest login
                   input#guestname.form-control(type="text", placeholder="Name")


### PR DESCRIPTION
Adding `data-bwignore="1"` to the #chatline input will stop Bitwarden from trying to autofill the chat field

https://github.com/calzoneman/sync/issues/994